### PR TITLE
Some changes

### DIFF
--- a/binning_dictionary.py
+++ b/binning_dictionary.py
@@ -163,7 +163,7 @@ binning_dictionary = {
   "ditau" : {
     "FS_t1_pt"   : np.linspace(0, 180, 36+1),
     "FS_t1_eta"  : np.linspace(-3, 3, 30+1),
-    "FS_t1_phi"  : np.linspace(-3.2, 3.2, 32+1),
+    "FS_t1_phi"  : np.linspace(-3.1416, 3.1416, 32+1),
     "FS_t1_DeepTauVSjet" : np.linspace(1, 9, 8+1),
     "FS_t1_DeepTauVSmu"  : np.linspace(1, 5, 4+1),
     "FS_t1_DeepTauVSe"   : np.linspace(1, 9, 8+1),
@@ -180,7 +180,7 @@ binning_dictionary = {
 
     "FS_t2_pt"   : np.linspace(0, 120, 24+1),
     "FS_t2_eta"  : np.linspace(-3, 3, 30+1),
-    "FS_t2_phi"  : np.linspace(-3.2, 3.2, 32+1),
+    "FS_t2_phi"  : np.linspace(-3.1416, 3.1416, 32+1),
     "FS_t2_DeepTauVSjet" : np.linspace(1, 9, 8+1),
     "FS_t2_DeepTauVSmu"  : np.linspace(1, 5, 4+1),
     "FS_t2_DeepTauVSe"   : np.linspace(1, 9, 8+1),
@@ -202,8 +202,8 @@ binning_dictionary = {
     "FS_mt_t1_MET" : np.linspace(0, 150, 30+1),
     "FS_mt_t2_MET" : np.linspace(0, 150, 30+1),
     "FS_mt_TOT"    : np.linspace(0, 50, 50+1),
-    "FS_dphi_t1t2" : np.linspace(-6.5, 6.5, 32+1),
-    "FS_deta_t1t2" : np.linspace(-4, 4, 31+1),
+    "FS_dphi_t1t2" : np.linspace(0, 3.1416, 32+1),
+    "FS_deta_t1t2" : np.linspace(0, 4, 32+1),
 
     "FS_t1_FLsig"  : np.linspace(-5, 20, 50+1),
     "FS_t1_FLX"    : np.linspace(-0.01, 0.01, 20+1), # most entries are at zero.
@@ -229,7 +229,7 @@ binning_dictionary = {
   "mutau" : {
     "FS_mu_pt"   : np.linspace(0, 120, 40+1),
     "FS_mu_eta"  : np.linspace(-3, 3, 30+1),
-    "FS_mu_phi"  : np.linspace(-3.2, 3.2, 32+1),
+    "FS_mu_phi"  : np.linspace(-3.1416, 3.1416, 32+1),
     "FS_mu_iso"  : np.linspace(0, 1, 25+1),
     "FS_mu_dxy"  : np.linspace(0, 0.025, 50+1),
     "FS_mu_dz"   : np.linspace(0, 0.05, 50+1), #np.linspace(0, 0.25, 50+1),
@@ -238,15 +238,15 @@ binning_dictionary = {
 
     "FS_tau_pt"  : np.linspace(0, 180, 36+1),
     "FS_tau_eta" : np.linspace(-3, 3, 30+1),
-    "FS_tau_phi" : np.linspace(-3.2, 3.2, 32+1),
+    "FS_tau_phi" : np.linspace(-3.1416, 3.1416, 32+1),
     "FS_tau_dxy"  : np.linspace(0, 0.025, 50+1), #np.linspace(0, 0.20, 50+1),
     "FS_tau_dz"   : np.linspace(0, 0.05, 50+1),  #np.linspace(0, 0.25, 50+1),
     "FS_tau_chg" : np.linspace(-2, 2, 5+1),
     "FS_tau_DM"  : np.linspace(0, 3, 4+1),
     "FS_tau_mass" : np.linspace(0, 3, 30+1),
 
-    "FS_dphi_mutau" : np.linspace(-6.5, 6.5, 32+1),
-    "FS_deta_mutau" : np.linspace(-4, 4, 31+1),
+    "FS_dphi_mutau" : np.linspace(0, 3.1416, 32+1),
+    "FS_deta_mutau" : np.linspace(0, 4, 32+1),
 
     "FS_tau_rawPNetVSjet" : np.linspace(0, 1, 50+1),
     "FS_tau_rawPNetVSmu"  : np.array([0, 0.95, 0.96, 0.97, 0.98, 0.99, 1]), # plot logx
@@ -258,7 +258,7 @@ binning_dictionary = {
   "etau" : {
     "FS_el_pt"   : np.linspace(20, 100, 50+1),
     "FS_el_eta"  : np.linspace(-3, 3, 30+1),
-    "FS_el_phi"  : np.linspace(-3.2, 3.2, 32+1),
+    "FS_el_phi"  : np.linspace(-3.1416, 3.1416, 32+1),
     "FS_el_iso"  : np.linspace(0, 1, 25+1),
     "FS_el_dxy"  : np.linspace(0, 0.05, 50+1),
     "FS_el_dz"   : np.linspace(0, 0.25, 50+1),
@@ -267,15 +267,15 @@ binning_dictionary = {
 
     "FS_tau_pt"  : np.linspace(20, 100, 50+1),
     "FS_tau_eta" : np.linspace(-3, 3, 30+1),
-    "FS_tau_phi" : np.linspace(-3.2, 3.2, 32+1),
+    "FS_tau_phi" : np.linspace(-3.1416, 3.1416, 32+1),
     "FS_tau_dxy" : np.linspace(0, 0.025, 25+1), #np.linspace(0, 0.20, 50+1),
     "FS_tau_dz"  : np.linspace(0, 0.05, 25+1),  #np.linspace(0, 0.25, 50+1),
     "FS_tau_chg" : np.linspace(-2, 2, 5+1),
     "FS_tau_DM"  : np.linspace(0, 3, 4+1), #0, 19, 20+1
     "FS_tau_mass" : np.linspace(0, 3, 30+1),
 
-    "FS_dphi_etau" : np.linspace(-6.5, 6.5, 32+1),
-    "FS_deta_etau" : np.linspace(-4, 4, 31+1),
+    "FS_dphi_etau" : np.linspace(0, 3.1416, 32+1),
+    "FS_deta_etau" : np.linspace(0, 4, 32+1),
 
     "FS_tau_rawPNetVSjet" : np.linspace(0, 1, 50+1),
     "FS_tau_rawPNetVSmu"  : np.array([0, 0.95, 0.96, 0.97, 0.98, 0.99, 1]), # plot logx
@@ -285,7 +285,7 @@ binning_dictionary = {
   "dimuon" : {
     "FS_m1_pt"   : np.linspace(0, 300, 60+1),
     "FS_m1_eta"  : np.linspace(-2.5, 2.5, 99+1),
-    "FS_m1_phi"  : np.linspace(-3.2, 3.2, 64+1),
+    "FS_m1_phi"  : np.linspace(-3.1416, 3.1416, 64+1),
     "FS_m1_iso"  : np.linspace(0, 1, 25+1),
     "FS_m1_dxy"  : np.linspace(0, 0.05, 50+1),
     "FS_m1_dz"   : np.linspace(0, 0.25, 50+1),
@@ -293,7 +293,7 @@ binning_dictionary = {
 
     "FS_m2_pt"   : np.linspace(0, 300, 60+1),
     "FS_m2_eta"  : np.linspace(-2.5, 2.5, 99+1),
-    "FS_m2_phi"  : np.linspace(-3.2, 3.2, 64+1),
+    "FS_m2_phi"  : np.linspace(-3.1416, 3.1416, 64+1),
     "FS_m2_iso"  : np.linspace(0, 1, 25+1),
     "FS_m2_dxy"  : np.linspace(0, 0.05, 50+1),
     "FS_m2_dz"   : np.linspace(0, 0.25, 50+1),
@@ -303,7 +303,7 @@ binning_dictionary = {
   "emu" : {
     "FS_el_pt"   : np.linspace(0, 120, 40+1),
     "FS_el_eta"  : np.linspace(-3, 3, 30+1),
-    "FS_el_phi"  : np.linspace(-3.2, 3.2, 32+1),
+    "FS_el_phi"  : np.linspace(-3.1416, 3.1416, 32+1),
     "FS_el_iso"  : np.linspace(0, 1, 25+1),
     "FS_el_dxy"  : np.linspace(0, 0.05, 50+1),
     "FS_el_dz"   : np.linspace(0, 0.25, 50+1),
@@ -311,7 +311,7 @@ binning_dictionary = {
 
     "FS_mu_pt"   : np.linspace(0, 120, 40+1),
     "FS_mu_eta"  : np.linspace(-3, 3, 30+1),
-    "FS_mu_phi"  : np.linspace(-3.2, 3.2, 32+1),
+    "FS_mu_phi"  : np.linspace(-3.1416, 3.1416, 32+1),
     "FS_mu_iso"  : np.linspace(0, 1, 25+1),
     "FS_mu_dxy"  : np.linspace(0, 0.025, 50+1),
     "FS_mu_dz"   : np.linspace(0, 0.25, 50+1),
@@ -331,9 +331,9 @@ binning_dictionary = {
     "CleanJetGT30_eta_1" : np.linspace(-5, 5, 50+1),
     "CleanJetGT30_eta_2" : np.linspace(-5, 5, 50+1),
     "CleanJetGT30_eta_3" : np.linspace(-5, 5, 50+1),
-    "CleanJetGT30_phi_1" : np.linspace(-3.2, 3.2, 32+1),
-    "CleanJetGT30_phi_2" : np.linspace(-3.2, 3.2, 32+1),
-    "CleanJetGT30_phi_3" : np.linspace(-3.2, 3.2, 32+1),
+    "CleanJetGT30_phi_1" : np.linspace(-3.1416, 3.1416, 32+1),
+    "CleanJetGT30_phi_2" : np.linspace(-3.1416, 3.1416, 32+1),
+    "CleanJetGT30_phi_3" : np.linspace(-3.1416, 3.1416, 32+1),
     "FS_mjj"     : np.linspace(0, 1500, 30+1),
     "FS_detajj"  : np.linspace(0, 7, 31+1),
     "FS_j1index" : np.linspace(0, 10, 10+1),
@@ -343,9 +343,9 @@ binning_dictionary = {
 
     # from branches
     "MET_pt"      : np.linspace(0, 150, 30+1),
-    "MET_phi"     : np.linspace(-3.2, 3.2, 32+1),
+    "MET_phi"     : np.linspace(-3.1416, 3.1416, 32+1),
     "PuppiMET_pt" : np.linspace(0, 150, 50+1),
-    "PuppiMET_phi": np.linspace(-3.2, 3.2, 32+1),
+    "PuppiMET_phi": np.linspace(-3.1416, 3.1416, 32+1),
     "nCleanJet"   : np.linspace(0, 8, 8+1),
     "CleanJet_pt" : np.linspace(20, 200, 30+1),
     "CleanJet_eta": np.linspace(-5, 5, 50+1),

--- a/calculate_functions.py
+++ b/calculate_functions.py
@@ -151,9 +151,9 @@ def calculate_dR(eta1, phi1, eta2, phi2):
 def phi_mpi_pi(delta_phi):
   '''return phi between a range of negative pi and pi'''
   if (delta_phi > np.pi):
-    return delta_phi - np.pi
+    return delta_phi - 2*np.pi
   elif (delta_phi < -np.pi):
-    return delta_phi + np.pi
+    return delta_phi + 2*np.pi
   else: # do nothing
     return delta_phi
 

--- a/cut_ditau_functions.py
+++ b/cut_ditau_functions.py
@@ -153,9 +153,8 @@ def make_ditau_cut(event_dictionary, DeepTau_version, skip_DeepTau, tau_pt_cut):
     mt_t2_MET = calculate_mt(t2_pt, t2_phi, MET_pt, MET_phi) 
     mt_TOT    = np.sqrt(mt_t1t2 + mt_t1_MET + mt_t2_MET)
 
-    dphi_t1t2 = phi_mpi_pi(t1_phi - t2_phi)
-    dphi_t1t2 = t1_phi - t2_phi
-    deta_t1t2 = t1_eta - t2_eta
+    dphi_t1t2 = np.acos(np.cos(t1_phi - t2_phi))
+    deta_t1t2 = abs(t1_eta - t2_eta)
 
     mvis_req = (mvis > 50) # remove disagreement at low mvis values
     deta_t1t2_req = (deta_t1t2 < 1.5) # try 2 also

--- a/cut_etau_functions.py
+++ b/cut_etau_functions.py
@@ -54,8 +54,8 @@ def make_etau_cut(event_dictionary, DeepTau_version, skip_DeepTau=False, tau_pt_
     tauMass = tau_mass[l2_idx]
     mt      = calculate_mt(elPt, elPhi, MET_pt, MET_phi)
 
-    dphi_etau = elPhi - tauPhi
-    deta_etau = elEta - elEta
+    dphi_etau = np.acos(np.cos(elPhi - tauPhi))
+    deta_etau = abs(elEta - tauEta)
 
     passTauPtAndEta  = ((tauPt > 30.0) and (abs(tauEta) < 2.5))
     pass31ElPt   = ((trg30el) and (elPt > 31.0) and (abs(elEta) < 2.5))
@@ -63,12 +63,12 @@ def make_etau_cut(event_dictionary, DeepTau_version, skip_DeepTau=False, tau_pt_
     pass36ElPt   = ((trg35el) and (elPt > 36.0) and (abs(elEta) < 2.5))
     # upper bound on cross trigger will change if lower single electron trigger included
     # HLT_Ele24_eta2p1_WPTight_Gsf_LooseDeepTauPFTauHPS30_eta2p1_CrossL1
-    passElPtCrossTrigger = ((crosstrg) and ((25.0 < elPt < 33.0) and (abs(elEta) < 2.1))
+    passElPtCrossTrigger = ((crosstrg) and ((25.0 < elPt < 31.0) and (abs(elEta) < 2.1))
                                        and ((tauPt > 35.0)       and (abs(tauEta) < 2.1)) ) 
     #passElPtCrossTrigger = False # dummy to turn off crosstrg
 
     # Medium (5) v Jet, VLoose (1) v Muon, Tight (6) v Ele
-    passTauDTLep  = ((vMu[tauBranchLoc] >= 1) and (vEle[tauBranchLoc] >= 5))
+    passTauDTLep  = ((vMu[tauBranchLoc] >= 1) and (vEle[tauBranchLoc] >= 6))
 
     single_DM_encoder = {0: 0, 1: 1, 10:2, 11:3}
     encoded_tau_decayMode = single_DM_encoder[tau_decayMode[tauBranchLoc]]
@@ -99,7 +99,7 @@ def make_etau_cut(event_dictionary, DeepTau_version, skip_DeepTau=False, tau_pt_
       FS_el_dxy.append(elDxy)
       FS_el_dz.append(elDz)
       FS_el_chg.append(elChg)
-      FS_el_mass.append(elMassVal)
+      FS_el_mass.append(elMass)
 
       FS_tau_pt.append(tauPt)
       FS_tau_eta.append(tauEta)

--- a/cut_mutau_functions.py
+++ b/cut_mutau_functions.py
@@ -63,8 +63,8 @@ def make_mutau_cut(event_dictionary, DeepTau_version, skip_DeepTau=False, tau_pt
     mt      = calculate_mt(muPt, muPhi, MET_pt, MET_phi)
     acoplan = calculate_acoplan(muPhi, tauPhi)
 
-    dphi_mutau = muPhi - tauPhi
-    deta_mutau = muEta - tauEta
+    dphi_mutau = np.acos(np.cos(muPhi - tauPhi))
+    deta_mutau = abs(muEta - tauEta)
 
     #tauPNetvJet = PNetvJet[tauBranchLoc]
     #tauPNetvMu  = PNetvMu[tauBranchLoc]

--- a/file_map_dictionary.py
+++ b/file_map_dictionary.py
@@ -127,6 +127,7 @@ full_file_map = {
   "ST_TWminus_LNu2Q"   : "ST/ST_TWminus_LNu2Q*",
 
   # WJ
+  #"WJetsIncNLO"      : "WJ/WJetsToLNu_HTauTau*",
   "WJetsToLNu_0JNLO" : "WJ/W0JetsToLNu_HTauTau*",
   "WJetsToLNu_1JNLO" : "WJ/W1JetsToLNu_HTauTau*",
   "WJetsToLNu_2JNLO" : "WJ/W2JetsToLNu_HTauTau*",

--- a/standard_plot.py
+++ b/standard_plot.py
@@ -195,7 +195,6 @@ if __name__ == "__main__":
   vars_to_plot = [var for var in vars_to_plot if "flav" not in var]
   CUSTOM_VARS = True
   if CUSTOM_VARS == True:
-    vars_to_plot = [var for var in vars_to_plot if "flav" not in var]
     if (final_state_mode == "ditau"):
       vars_to_plot = ["HTT_m_vis", 
                     "FS_t1_pt", "FS_t1_eta", "FS_t1_phi", "FS_t1_DM", "FS_t1_mass",
@@ -210,7 +209,7 @@ if __name__ == "__main__":
                     "FS_dphi_mutau", "FS_deta_mutau",
                     "PuppiMET_pt", "HTT_H_pt_using_PUPPI_MET",
                     "FS_mt", "nCleanJetGT30"]
-  plots_unrolled = False
+  plots_unrolled = True
   if (plots_unrolled == True):
     rolled_vars = ["FastMTT_mass"]
     H_pT_bins = [0, 45, 80, 120, 200, 350, 450]
@@ -232,12 +231,12 @@ if __name__ == "__main__":
   
         for ith_bin in range(len(unrolled_bins)):
           h_data_ur = get_binned_data(final_state_mode, testing, data_dictionary, rolled_var, xbins, lumi,
-                                        unrolled_bins_data, mask_n=ith_bin)
+                                        mask=unrolled_bins_data, mask_n=ith_bin)
           h_backgrounds_ur = get_binned_backgrounds(final_state_mode, testing, background_dictionary, rolled_var, xbins, lumi,
-                                        unrolled_bins_background, mask_n=ith_bin)
+                                        mask=unrolled_bins_background, mask_n=ith_bin)
           h_summed_backgrounds_ur = get_summed_backgrounds(h_backgrounds_ur)
           h_signals_ur = get_binned_signals(final_state_mode, testing, signal_dictionary, rolled_var, xbins, lumi,
-                                        unrolled_bins_signal, mask_n=ith_bin)
+                                        mask=unrolled_bins_signal, mask_n=ith_bin)
           blind, blind_range = False, []
           # remove yields for these plots by setting presentation_mode to True below
           plot_data(   stack_n_ax[ith_bin], xbins, h_data_ur,        lumi, True, blind, blind_range)
@@ -266,7 +265,7 @@ if __name__ == "__main__":
             print("haven't styled that variable yet, no text added")
           add_text(stack_n_ax[ith_bin], text, loc=[0.05, 0.90])
 
-        plt.savefig(plot_dir + "/" + "unrolled_TauPtCategory_" + tau_pt_cut + "_" + str(rolled_var) + ".png")
+        plt.savefig(plot_dir + "/" + "unrolled_TauPtCategory_" + tau_pt_cut + "_" + str(rolled_var) + "-" + str(unrolled_var) + ".png")
  
 
   for var in vars_to_plot:


### PR DESCRIPTION
Proposed changes:
- phi plots range adjusted to +/- 3.1416 instead of 3.2, to be the edge bins not as empty
- deta/dphi variables made absolute, plotted starting from 0

Some fixes:
- e-tau related
- WJ from MC was still using weight, assuming stitching of inclusive and njet-binned samples: This is now commented out
- Adding WJ to list of MC families for e-tau (needed also for e-mu?)
- Changed output plot name of unrolled plots, to be able to separate for different unrolled variables
- I had some trouble in `get_binned_process` where the `mask` dict (not a list btw) would be empty, fixed by specifying that the `unrolled_bins_...` dict should be set as this optional argument

Other:
- I commented some lines in `plotting_functions.py`, l.719-723. I guess that's not needed because of what's done in l.707 here? (Uncommenting result in crash, because "Other" not in list anymore)
- I turned "unrolled_plots" to True. Would there ever be a reason of not wanting these?